### PR TITLE
Fix disposable handlers.

### DIFF
--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -105,8 +105,8 @@ private extension Process {
         outputHandle?.closeFile()
         errorHandle?.closeFile()
 
-        FileHandle.standardError.readabilityHandler = nil
-        FileHandle.standardOutput.readabilityHandler = nil
+        outputPipe.fileHandleForReading.readabilityHandler = nil
+        errorPipe.fileHandleForReading.readabilityHandler = nil
 
         if terminationStatus != 0 {
             throw ShellOutError(


### PR DESCRIPTION
Instead of correctly dispose the handlers for the created `Pipe`, the
STDERR and STDOUT were disposed.

See: https://developer.apple.com/reference/foundation/filehandle/1412413-readabilityhandler