### PR TITLE
ShellOutError: Implement description

### DIFF
--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -336,6 +336,12 @@ extension ShellOutError: CustomStringConvertible {
     }
 }
 
+extension ShellOutError: LocalizedError {
+    public var errorDescription: String? {
+        return description
+    }
+}
+
 // MARK: - Private
 
 private extension Process {

--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -325,6 +325,17 @@ public struct ShellOutError: Swift.Error {
     public var output: String { return outputData.shellOutput() }
 }
 
+extension ShellOutError: CustomStringConvertible {
+    public var description: String {
+        return """
+               ShellOut encountered an error
+               Status code: \(terminationStatus)
+               Message: "\(message)"
+               Output: "\(output)"
+               """
+    }
+}
+
 // MARK: - Private
 
 private extension Process {

--- a/Tests/ShellOutTests/ShellOutTests.swift
+++ b/Tests/ShellOutTests/ShellOutTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-import ShellOut
+@testable import ShellOut
 
 class ShellOutTests: XCTestCase {
     func testWithoutArguments() throws {
@@ -63,6 +63,26 @@ class ShellOutTests: XCTestCase {
         } catch {
             XCTFail("Invalid error type: \(error)")
         }
+    }
+
+    func testErrorDescription() {
+        let errorMessage = "Hey, I'm an error!"
+        let output = "Some output"
+
+        let error = ShellOutError(
+            terminationStatus: 7,
+            errorData: errorMessage.data(using: .utf8)!,
+            outputData: output.data(using: .utf8)!
+        )
+
+        let expectedErrorDescription = """
+                                       ShellOut encountered an error
+                                       Status code: 7
+                                       Message: "Hey, I'm an error!"
+                                       Output: "Some output"
+                                       """
+
+        XCTAssertEqual("\(error)", expectedErrorDescription)
     }
 
     func testCapturingOutputWithHandle() throws {

--- a/Tests/ShellOutTests/ShellOutTests.swift
+++ b/Tests/ShellOutTests/ShellOutTests.swift
@@ -83,6 +83,7 @@ class ShellOutTests: XCTestCase {
                                        """
 
         XCTAssertEqual("\(error)", expectedErrorDescription)
+        XCTAssertEqual(error.localizedDescription, expectedErrorDescription)
     }
 
     func testCapturingOutputWithHandle() throws {


### PR DESCRIPTION
This change makes `ShellOutError` conform to `CustomStringConvertible`, to enable more informative error outputs and logging.