### PR TITLE
Don't close standard file handlers

### DIFF
--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -380,11 +380,11 @@ private extension Process {
         #endif
 
         waitUntilExit()
-        
+
         if let handle = outputHandle, !handle.isStandard {
             handle.closeFile()
         }
-        
+
         if let handle = errorHandle, !handle.isStandard {
             handle.closeFile()
         }
@@ -401,7 +401,7 @@ private extension Process {
                 outputData: outputData
             )
         }
-        
+
         return outputData.shellOutput()
     }
 }
@@ -419,7 +419,7 @@ private extension Data {
         guard let output = String(data: self, encoding: .utf8) else {
             return ""
         }
-        
+
         guard !output.hasSuffix("\n") else {
             let endIndex = output.index(before: output.endIndex)
             return String(output[..<endIndex])


### PR DESCRIPTION
When 'shelling out' to an async operation, `FileHandler.standardOutput` can be passed in to see the output in realtime, in the same way as if the command had been executed in the Terminal:

`try shellOut(to: "pod repo update", outputHandle: FileHandle.standardOutput)`

ShellOut currently calls `closeFile()` on the passed in  output handler and error handler. In the case that one of the 'standard' handlers has been passed in, this causes issues such as `print()` not working.

This PR checks for the 3 standard handlers (input, output, error) and bypasses the call to `closeFile()`. Any other passed in `FileHandler` will receive the call.

@JohnSundell let me know how you feel about this solution. It does add a special casing for the 3 handlers (which is a bit weird), but the advantage is that there's no additional complexity to the api, which is probably a good thing for a scripting library!