### PR TITLE
Fix Filehandler bugs & Swift 4 package comment. Groundwork for Async output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
-os: linux
+os:
+    - linux
+    - osx
+env:
+    - SWIFT_VERSION=4.0
+    - SWIFT_VERSION=4.1
+osx_image: xcode9
 language: generic
 sudo: required
 dist: trusty
 install:
-    - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
+    - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 script:
     - swift test

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.1
+// swift-tools-version:4.0
 
 /**
  *  ShellOut

--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -362,7 +362,7 @@ extension FileHandle: Handle {
     }
     
     public func endHandling() {
-        closeFile()
+        if shouldBeClosed { closeFile() }
     }
 }
 
@@ -457,6 +457,14 @@ private extension Process {
 
             return outputData.shellOutput()
         }
+    }
+}
+
+private extension FileHandle {
+    var shouldBeClosed: Bool {
+        return self !== FileHandle.standardOutput &&
+            self !== FileHandle.standardError &&
+            self !== FileHandle.standardInput
     }
 }
 

--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -366,25 +366,6 @@ extension FileHandle: Handle {
     }
 }
 
-/// Handle to get async output from the command. The `handlingClosure` will be called each time new output string appear.
-public struct StringHandle: Handle {
-    private let handlingClosure: (String) -> Void
-
-    /// Default initializer
-    ///
-    /// - Parameter handlingClosure: closure called each time new output string is provided
-    public init(handlingClosure: @escaping (String) -> Void) {
-        self.handlingClosure = handlingClosure
-    }
-    
-    public func handle(data: Data) {
-        guard !data.isEmpty else { return }
-        let output = data.shellOutput()
-        guard !output.isEmpty else { return }
-        handlingClosure(output)
-    }
-}
-
 // MARK: - Private
 
 private extension Process {

--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -409,16 +409,16 @@ private extension Process {
 
         #if !os(Linux)
         outputPipe.fileHandleForReading.readabilityHandler = { handler in
+            let data = handler.availableData
             outputQueue.async {
-                let data = handler.availableData
                 outputData.append(data)
                 outputHandle?.handle(data: data)
             }
         }
 
         errorPipe.fileHandleForReading.readabilityHandler = { handler in
+            let data = handler.availableData
             outputQueue.async {
-                let data = handler.availableData
                 errorData.append(data)
                 errorHandle?.handle(data: data)
             }

--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -15,9 +15,9 @@ import Dispatch
  *  - parameter command: The command to run
  *  - parameter arguments: The arguments to pass to the command
  *  - parameter path: The path to execute the commands at (defaults to current folder)
- *  - parameter outputHandle: Any `FileHandle` that any output (STDOUT) should be redirected to
+ *  - parameter outputHandle: Any `Handle` that any output (STDOUT) should be redirected to
  *              (at the moment this is only supported on macOS)
- *  - parameter errorHandle: Any `FileHandle` that any error output (STDERR) should be redirected to
+ *  - parameter errorHandle: Any `Handle` that any error output (STDERR) should be redirected to
  *              (at the moment this is only supported on macOS)
  *
  *  - returns: The output of running the command
@@ -29,8 +29,8 @@ import Dispatch
 @discardableResult public func shellOut(to command: String,
                                         arguments: [String] = [],
                                         at path: String = ".",
-                                        outputHandle: FileHandle? = nil,
-                                        errorHandle: FileHandle? = nil) throws -> String {
+                                        outputHandle: Handle? = nil,
+                                        errorHandle: Handle? = nil) throws -> String {
     let process = Process()
     let command = "cd \(path.escapingSpaces) && \(command) \(arguments.joined(separator: " "))"
     return try process.launchBash(with: command, outputHandle: outputHandle, errorHandle: errorHandle)
@@ -41,9 +41,9 @@ import Dispatch
  *
  *  - parameter commands: The commands to run
  *  - parameter path: The path to execute the commands at (defaults to current folder)
- *  - parameter outputHandle: Any `FileHandle` that any output (STDOUT) should be redirected to
+ *  - parameter outputHandle: Any `Handle` that any output (STDOUT) should be redirected to
  *              (at the moment this is only supported on macOS)
- *  - parameter errorHandle: Any `FileHandle` that any error output (STDERR) should be redirected to
+ *  - parameter errorHandle: Any `Handle` that any error output (STDERR) should be redirected to
  *              (at the moment this is only supported on macOS)
  *
  *  - returns: The output of running the command
@@ -54,8 +54,8 @@ import Dispatch
  */
 @discardableResult public func shellOut(to commands: [String],
                                         at path: String = ".",
-                                        outputHandle: FileHandle? = nil,
-                                        errorHandle: FileHandle? = nil) throws -> String {
+                                        outputHandle: Handle? = nil,
+                                        errorHandle: Handle? = nil) throws -> String {
     let command = commands.joined(separator: " && ")
     return try shellOut(to: command, at: path, outputHandle: outputHandle, errorHandle: errorHandle)
 }
@@ -65,8 +65,8 @@ import Dispatch
  *
  *  - parameter command: The command to run
  *  - parameter path: The path to execute the commands at (defaults to current folder)
- *  - parameter outputHandle: Any `FileHandle` that any output (STDOUT) should be redirected to
- *  - parameter errorHandle: Any `FileHandle` that any error output (STDERR) should be redirected to
+ *  - parameter outputHandle: Any `Handle` that any output (STDOUT) should be redirected to
+ *  - parameter errorHandle: Any `Handle` that any error output (STDERR) should be redirected to
  *
  *  - returns: The output of running the command
  *  - throws: `ShellOutError` in case the command couldn't be performed, or it returned an error
@@ -78,8 +78,8 @@ import Dispatch
  */
 @discardableResult public func shellOut(to command: ShellOutCommand,
                                         at path: String = ".",
-                                        outputHandle: FileHandle? = nil,
-                                        errorHandle: FileHandle? = nil) throws -> String {
+                                        outputHandle: Handle? = nil,
+                                        errorHandle: Handle? = nil) throws -> String {
     return try shellOut(to: command.string, at: path, outputHandle: outputHandle, errorHandle: errorHandle)
 }
 
@@ -343,10 +343,52 @@ extension ShellOutError: LocalizedError {
     }
 }
 
+/// Protocol adopted by objects that handles command output
+public protocol Handle {
+    /// Method called each time command provide new output data
+    func handle(data: Data)
+
+    /// Optional method called when command has finished to close the handle
+    func endHandling()
+}
+
+public extension Handle {
+    func endHandling() {}
+}
+
+extension FileHandle: Handle {
+    public func handle(data: Data) {
+        write(data)
+    }
+    
+    public func endHandling() {
+        closeFile()
+    }
+}
+
+/// Handle to get async output from the command. The `handlingClosure` will be called each time new output string appear.
+public struct StringHandle: Handle {
+    private let handlingClosure: (String) -> Void
+
+    /// Default initializer
+    ///
+    /// - Parameter handlingClosure: closure called each time new output string is provided
+    public init(handlingClosure: @escaping (String) -> Void) {
+        self.handlingClosure = handlingClosure
+    }
+    
+    public func handle(data: Data) {
+        guard !data.isEmpty else { return }
+        let output = data.shellOutput()
+        guard !output.isEmpty else { return }
+        handlingClosure(output)
+    }
+}
+
 // MARK: - Private
 
 private extension Process {
-    @discardableResult func launchBash(with command: String, outputHandle: FileHandle? = nil, errorHandle: FileHandle? = nil) throws -> String {
+    @discardableResult func launchBash(with command: String, outputHandle: Handle? = nil, errorHandle: Handle? = nil) throws -> String {
         launchPath = "/bin/bash"
         arguments = ["-c", command]
 
@@ -370,7 +412,7 @@ private extension Process {
             outputQueue.async {
                 let data = handler.availableData
                 outputData.append(data)
-                outputHandle?.write(data)
+                outputHandle?.handle(data: data)
             }
         }
 
@@ -378,7 +420,7 @@ private extension Process {
             outputQueue.async {
                 let data = handler.availableData
                 errorData.append(data)
-                errorHandle?.write(data)
+                errorHandle?.handle(data: data)
             }
         }
         #endif
@@ -394,8 +436,8 @@ private extension Process {
 
         waitUntilExit()
 
-        outputHandle?.closeFile()
-        errorHandle?.closeFile()
+        outputHandle?.endHandling()
+        errorHandle?.endHandling()
 
         #if !os(Linux)
         outputPipe.fileHandleForReading.readabilityHandler = nil

--- a/Tests/ShellOutTests/ShellOutTests.swift
+++ b/Tests/ShellOutTests/ShellOutTests.swift
@@ -107,6 +107,26 @@ class ShellOutTests: XCTestCase {
         XCTAssertEqual(output + "\n", String(data: capturedData, encoding: .utf8))
     }
 
+    func testMultipleCallsToStandardOut() throws {
+        let standardOut = FileHandle.standardOutput
+
+        /// Do not wrap these calls in XCTAssertNoThrow as it suppresses the error and the test will
+        /// always pass. These calls will trap if the standardOut FileHandle is closed.
+        try shellOut(to: "echo", arguments: ["Hello"], outputHandle: standardOut)
+        try shellOut(to: "echo", arguments: ["Hello"], outputHandle: standardOut)
+
+    }
+
+    func testMultipleCallsToStandardError() throws {
+        let standardError = FileHandle.standardError
+
+        /// Do not wrap these calls in XCTAssertNoThrow as it suppresses the error and the test will
+        /// always pass. These calls will trap if the standardError FileHandle is closed.
+        _ = try? shellOut(to: "bash 'exit 1'", arguments: [], errorHandle: standardError)
+        _ = try? shellOut(to: "bash 'exit 1'", arguments: [], errorHandle: standardError)
+    }
+
+
     func testCapturingOutputWithStringHandle() throws {
         var stringHandleOutput = ""
         let stringHandle = StringHandle { stringHandleOutput.append($0) }

--- a/Tests/ShellOutTests/ShellOutTests.swift
+++ b/Tests/ShellOutTests/ShellOutTests.swift
@@ -114,7 +114,6 @@ class ShellOutTests: XCTestCase {
         /// always pass. These calls will trap if the standardOut FileHandle is closed.
         try shellOut(to: "echo", arguments: ["Hello"], outputHandle: standardOut)
         try shellOut(to: "echo", arguments: ["Hello"], outputHandle: standardOut)
-
     }
 
     func testMultipleCallsToStandardError() throws {


### PR DESCRIPTION
👋 @JohnSundell.

This PR is a combination of work from @gwikiera & @SteveBarnegren (Added as a coauthor to the appropriate commit). If we merge this PR we can close #30 & #23. 

**Changes**
* Add Handler protocol enabling custom async output. 
  * Fixes #11 (Async output)
* Ensure standardOutput, standardInput & standardError are not closed. 
  * Fixes #18 (Incomplete Standard output)
* Configure Travis to run tests on MacOS & Linux against Swift 4.0 & 4.1

**Partially Reverted**
* #31 - Package.swift. The tools comment should remain at 4.0 otherwise consumers can't build ShellOut with swift 4.0


 