### PR TITLE
Capture available data early

### DIFF
--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -367,16 +367,16 @@ private extension Process {
 
         #if !os(Linux)
         outputPipe.fileHandleForReading.readabilityHandler = { handler in
+            let data = handler.availableData
             outputQueue.async {
-                let data = handler.availableData
                 outputData.append(data)
                 outputHandle?.write(data)
             }
         }
 
         errorPipe.fileHandleForReading.readabilityHandler = { handler in
+            let data = handler.availableData
             outputQueue.async {
-                let data = handler.availableData
                 errorData.append(data)
                 errorHandle?.write(data)
             }


### PR DESCRIPTION
The availableData object should be captured in the event handler. If you delay reading the data to the synchronization queue, the pipe may be closed already (leading to an ObjC exception you can't catch).