### PR TITLE
Updated to Swift 5.1 and fixed deprecations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.1
 
 /**
  *  ShellOut

--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -376,7 +376,12 @@ extension ShellOutError: LocalizedError {
 
 private extension Process {
     @discardableResult func launchBash(with command: String, outputHandle: FileHandle? = nil, errorHandle: FileHandle? = nil) throws -> String {
-        launchPath = "/bin/bash"
+
+        if #available(OSX 10.13, *) {
+            executableURL = URL(fileURLWithPath: "/bin/bash")
+        } else {
+            launchPath = "/bin/bash"
+        }
         arguments = ["-c", command]
 
         // Because FileHandle's readabilityHandler might be called from a
@@ -394,7 +399,6 @@ private extension Process {
         let errorPipe = Pipe()
         standardError = errorPipe
 
-        #if !os(Linux)
         outputPipe.fileHandleForReading.readabilityHandler = { handler in
             let data = handler.availableData
             outputQueue.async {
@@ -410,16 +414,12 @@ private extension Process {
                 errorHandle?.write(data)
             }
         }
-        #endif
 
-        launch()
-
-        #if os(Linux)
-        outputQueue.sync {
-            outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-            errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if #available(OSX 10.13, *) {
+            try run()
+        } else {
+            launch()
         }
-        #endif
 
         waitUntilExit()
 
@@ -431,10 +431,8 @@ private extension Process {
             handle.closeFile()
         }
 
-        #if !os(Linux)
         outputPipe.fileHandleForReading.readabilityHandler = nil
         errorPipe.fileHandleForReading.readabilityHandler = nil
-        #endif
 
         // Block until all writes have occurred to outputData and errorData,
         // and then read the data back out.

--- a/Tests/ShellOutTests/ShellOutTests+Linux.swift
+++ b/Tests/ShellOutTests/ShellOutTests+Linux.swift
@@ -14,9 +14,14 @@ extension ShellOutTests {
         ("testWithArguments", testWithArguments),
         ("testWithInlineArguments", testWithInlineArguments),
         ("testSingleCommandAtPath", testSingleCommandAtPath),
+        ("testSingleCommandAtPathContainingSpace", testSingleCommandAtPathContainingSpace),
+        ("testSingleCommandAtPathContainingTilde", testSingleCommandAtPathContainingTilde),
         ("testSeriesOfCommands", testSeriesOfCommands),
         ("testSeriesOfCommandsAtPath", testSeriesOfCommandsAtPath),
         ("testThrowingError", testThrowingError),
+        ("testErrorDescription", testErrorDescription),
+        ("testCapturingOutputWithHandle", testCapturingOutputWithHandle),
+        ("testCapturingErrorWithHandle", testCapturingErrorWithHandle),
         ("testGitCommands", testGitCommands),
         ("testSwiftPackageManagerCommands", testSwiftPackageManagerCommands)
     ]

--- a/Tests/ShellOutTests/ShellOutTests.swift
+++ b/Tests/ShellOutTests/ShellOutTests.swift
@@ -41,8 +41,8 @@ class ShellOutTests: XCTestCase {
     }
 
     func testSingleCommandAtPathContainingTilde() throws {
-        let homeContents = try shellOut(to: "ls", at: "~")
-        XCTAssertFalse(homeContents.isEmpty)
+        let homeFolders = try shellOut(to: "ls", at: "~/..")
+        XCTAssertFalse(homeFolders.isEmpty)
     }
 
     func testSeriesOfCommands() throws {


### PR DESCRIPTION
I noticed, while building Publish with Swift 5.1 on Linux, that ShellOut was giving build warnings related to `launchPath` and `launch()` being deprecated. As I was investigating, I found that several of the tests were not running on Linux, and were actually failing when included. This PR addresses the following issues:

- Added missing tests to `ShellOutTests.allTests`.
- The `#if os` checks in `Process.launchBash(with:outputHandle:errorHandle:)` are no longer needed, as `FileHandle.readabilityHandler` was implemented and [merged](https://github.com/apple/swift-corelibs-foundation/commit/fc96d7fd139bc894689b5cc13a22d9c52424caf8) in Swift 5.1. This means both macOS and Linux can use the same code paths (this was not true when d18b7b6 was committed). This also fixes most of the tests.
- Added `if #available(OSX 10.13, *)` checks to use `executableURL` and `run()` on current macOS and Linux targets. Defaults to the older API on earlier versions of macOS. This gets rid of the build warnings.
- Changed `testSingleCommandAtPathContainingTilde()` to run at `~/..` (typically `/Users` on macOS and `/home` on Linux) instead of `~`. This is because Swift docker images, which are one of the easier ways to test Swift on Linux, have an empty home directory by default, and thus fail this test. By contrast, `~/..` must contain at least `~`, and still tests that paths with `~` work.

I think this should cut a new version release, as it changes the minimum Swift version from 4.2 to 5.1.