### PR TITLE
Hides ShellOut implementation in iOS target

### DIFF
--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -3,7 +3,7 @@
  *  Copyright (c) John Sundell 2017
  *  Licensed under the MIT license. See LICENSE file.
  */
-
+#if os(macOS) || os(Linux)
 import Foundation
 import Dispatch
 
@@ -497,3 +497,4 @@ private extension String {
         self = appending(arguments: arguments)
     }
 }
+#endif

--- a/Tests/ShellOutTests/ShellOutTests.swift
+++ b/Tests/ShellOutTests/ShellOutTests.swift
@@ -3,7 +3,7 @@
  *  Copyright (c) John Sundell 2017
  *  Licensed under the MIT license. See LICENSE file.
  */
-
+#if os(macOS) || os(Linux)
 import XCTest
 @testable import ShellOut
 
@@ -175,3 +175,4 @@ class ShellOutTests: XCTestCase {
         XCTAssertTrue(try shellOut(to: "ls -a", at: packagePath).contains("SwiftPackageManagerTest.xcodeproj"))
     }
 }
+#endif


### PR DESCRIPTION
As mentioned in #45, if a target in your workspace directly or indirectly depends on ShellOut and you try to build the SwiftUI preview target, the compilation fails as Process is not available on iOS. Swift Package Manager does currently not supported limiting on which platforms a package can be built. This PR hides the ShellOut implementation using `# if os(macOS) || os(Linux)` in the iOS target so that its build succeeds. 
