### PR TITLE
Bump swift tools version to 5.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.2
 
 /**
  *  ShellOut


### PR DESCRIPTION
There was a fix in Swift 5.2 where dependency resolution became based on the products used by a package, and not all of the dependencies declared by the dependency. ShellOut using the 4.2 tools version caused my Swift package to fall back to the older way of resolving dependencies, which broke things on my package. Bumping ShellOut to the 5.2 tools version got all of my dependencies on that minimum version, and my package resolved once again.

For reference [here's the Swift Evolution proposal](https://github.com/apple/swift-evolution/blob/master/proposals/0226-package-manager-target-based-dep-resolution.md) which brought this fix about.