### PR TITLE
Fix warnings on Linux

### DIFF
--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -380,7 +380,11 @@ extension ShellOutError: LocalizedError {
 
 private extension Process {
     @discardableResult func launchBash(with command: String, outputHandle: FileHandle? = nil, errorHandle: FileHandle? = nil) throws -> String {
+        #if os(Linux)
+        executableURL = URL(fileURLWithPath: "/bin/bash")
+        #else
         launchPath = "/bin/bash"
+        #endif
         arguments = ["-c", command]
 
         // Because FileHandle's readabilityHandler might be called from a
@@ -416,7 +420,11 @@ private extension Process {
         }
         #endif
 
+        #if os(Linux)
+        try run()
+        #else
         launch()
+        #endif
 
         #if os(Linux)
         outputQueue.sync {


### PR DESCRIPTION
I've only been able to test this with Swift 5.5 on macOS and Linux: both build and pass tests without warnings.

I still have the Makefile around from when I started looking into this to test more platforms but I've since moved to an M1 and don't have hardware within easy reach to actually run the targets 😆 

Not sure what automated testing there is for the repo but I can make an effort to run the full matrix if it helps. Let me know!

```
clean:
	@# just delete specific directories instead of .builds so we don't
	@# have to re-fetch dependencies
	@rm -f .build/debug
	@rm -rf .build/x86_64-apple-macosx/
	@rm -rf .build/x86_64-unknown-linux/
	@rm -rf .build/x86_64-unknown-linux-gnu/

macos-spm-4.2: clean
	@echo
	@echo === Building $@ ===
	env DEVELOPER_DIR=/Applications/Xcode_10.1 xcrun swift build

macos-spm-5.0: clean
	@echo
	@echo === Building $@ ===
	env DEVELOPER_DIR=/Applications/Xcode_10.3.app xcrun swift build

macos-spm-5.1: clean
	@echo
	@echo === Building $@ ===
	env DEVELOPER_DIR=/Applications/Xcode_11.3.1.app xcrun swift build

macos-spm-5.2: clean
	@echo
	@echo === Building $@ ===
	env DEVELOPER_DIR=/Applications/Xcode_11.6.app xcrun swift build

macos-spm-5.3: clean
	@echo
	@echo === Building $@ ===
	env DEVELOPER_DIR=/Applications/Xcode_12_beta_5.app xcrun swift build

linux-4.2: clean
	@echo
	@echo === Building $@ ===
	docker run --rm -v "$(PWD)":/host -w /host swift:4.2.4 swift build

linux-5.0: clean
	@echo
	@echo === Building $@ ===
	docker run --rm -v "$(PWD)":/host -w /host swift:5.0.3 swift build

linux-5.1: clean
	@echo
	@echo === Building $@ ===
	docker run --rm -v "$(PWD)":/host -w /host swift:5.1.5 swift build --enable-test-discovery

linux-5.2: clean
	@echo
	@echo === Building $@ ===
	docker run --rm -v "$(PWD)":/host -w /host swift:5.2.4 swift build --enable-test-discovery

linux-5.3: clean
	@echo
	@echo === Building $@ ===
	docker run --rm -v "$(PWD)":/host -w /host "swiftlang/swift:nightly-5.3@sha256:99cd46394189f06ee7f7221d9873f273e5d0d4efe89824d201b0d9838aec4f50" swift build --enable-test-discovery

#	macos-spm-4.2 \
	macos-spm-5.0 
all: \
	macos-spm-5.1 \
	macos-spm-5.2 \
	macos-spm-5.3 \
	linux-4.2 \
	linux-5.0 \
	linux-5.1 \
	linux-5.2 \
	linux-5.3
```