### PR TITLE
Allow `--quiet` to be controlled in the predefined git commands

### DIFF
--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -131,45 +131,57 @@ public extension ShellOutCommand {
     }
 
     /// Clone a git repository at a given URL
-    static func gitClone(url: URL, to path: String? = nil, allowingPrompt: Bool = true) -> ShellOutCommand {
+    static func gitClone(url: URL, to path: String? = nil, allowingPrompt: Bool = true, quiet: Bool = true) -> ShellOutCommand {
         var command = "\(git(allowingPrompt: allowingPrompt)) clone \(url.absoluteString)"
         path.map { command.append(argument: $0) }
-        command.append(" --quiet")
+
+        if quiet {
+            command.append(" --quiet")
+        }
 
         return ShellOutCommand(string: command)
     }
 
     /// Create a git commit with a given message (also adds all untracked file to the index)
-    static func gitCommit(message: String, allowingPrompt: Bool = true) -> ShellOutCommand {
+    static func gitCommit(message: String, allowingPrompt: Bool = true, quiet: Bool = true) -> ShellOutCommand {
         var command = "\(git(allowingPrompt: allowingPrompt)) add . && git commit -a -m"
         command.append(argument: message)
-        command.append(" --quiet")
+
+        if quiet {
+            command.append(" --quiet")
+        }
 
         return ShellOutCommand(string: command)
     }
 
     /// Perform a git push
-    static func gitPush(remote: String? = nil, branch: String? = nil, allowingPrompt: Bool = true) -> ShellOutCommand {
+    static func gitPush(remote: String? = nil, branch: String? = nil, allowingPrompt: Bool = true, quiet: Bool = true) -> ShellOutCommand {
         var command = "\(git(allowingPrompt: allowingPrompt)) push"
         remote.map { command.append(argument: $0) }
         branch.map { command.append(argument: $0) }
-        command.append(" --quiet")
+
+        if quiet {
+            command.append(" --quiet")
+        }
 
         return ShellOutCommand(string: command)
     }
 
     /// Perform a git pull
-    static func gitPull(remote: String? = nil, branch: String? = nil, allowingPrompt: Bool = true) -> ShellOutCommand {
+    static func gitPull(remote: String? = nil, branch: String? = nil, allowingPrompt: Bool = true, quiet: Bool = true) -> ShellOutCommand {
         var command = "\(git(allowingPrompt: allowingPrompt)) pull"
         remote.map { command.append(argument: $0) }
         branch.map { command.append(argument: $0) }
-        command.append(" --quiet")
+
+        if quiet {
+            command.append(" --quiet")
+        }
 
         return ShellOutCommand(string: command)
     }
 
     /// Run a git submodule update
-    static func gitSubmoduleUpdate(initializeIfNeeded: Bool = true, recursive: Bool = true, allowingPrompt: Bool = true) -> ShellOutCommand {
+    static func gitSubmoduleUpdate(initializeIfNeeded: Bool = true, recursive: Bool = true, allowingPrompt: Bool = true, quiet: Bool = true) -> ShellOutCommand {
         var command = "\(git(allowingPrompt: allowingPrompt)) submodule update"
 
         if initializeIfNeeded {
@@ -180,14 +192,20 @@ public extension ShellOutCommand {
             command.append(" --recursive")
         }
 
-        command.append(" --quiet")
+        if quiet {
+            command.append(" --quiet")
+        }
+
         return ShellOutCommand(string: command)
     }
 
     /// Checkout a given git branch
-    static func gitCheckout(branch: String) -> ShellOutCommand {
-        let command = "git checkout".appending(argument: branch)
-                                    .appending(" --quiet")
+    static func gitCheckout(branch: String, quiet: Bool = true) -> ShellOutCommand {
+        var command = "git checkout".appending(argument: branch)
+
+        if quiet {
+            command.append(" --quiet")
+        }
 
         return ShellOutCommand(string: command)
     }

--- a/Sources/ShellOut.swift
+++ b/Sources/ShellOut.swift
@@ -20,6 +20,7 @@ import Dispatch
  *              (at the moment this is only supported on macOS)
  *  - parameter errorHandle: Any `FileHandle` that any error output (STDERR) should be redirected to
  *              (at the moment this is only supported on macOS)
+ *  - parameter environment: The environment for the command.
  *
  *  - returns: The output of running the command
  *  - throws: `ShellOutError` in case the command couldn't be performed, or it returned an error
@@ -33,14 +34,16 @@ import Dispatch
     at path: String = ".",
     process: Process = .init(),
     outputHandle: FileHandle? = nil,
-    errorHandle: FileHandle? = nil
+    errorHandle: FileHandle? = nil,
+    environment: [String : String]? = nil
 ) throws -> String {
     let command = "cd \(path.escapingSpaces) && \(command) \(arguments.joined(separator: " "))"
 
     return try process.launchBash(
         with: command,
         outputHandle: outputHandle,
-        errorHandle: errorHandle
+        errorHandle: errorHandle,
+        environment: environment
     )
 }
 
@@ -54,6 +57,7 @@ import Dispatch
  *              (at the moment this is only supported on macOS)
  *  - parameter errorHandle: Any `FileHandle` that any error output (STDERR) should be redirected to
  *              (at the moment this is only supported on macOS)
+ *  - parameter environment: The environment for the command.
  *
  *  - returns: The output of running the command
  *  - throws: `ShellOutError` in case the command couldn't be performed, or it returned an error
@@ -66,7 +70,8 @@ import Dispatch
     at path: String = ".",
     process: Process = .init(),
     outputHandle: FileHandle? = nil,
-    errorHandle: FileHandle? = nil
+    errorHandle: FileHandle? = nil,
+    environment: [String : String]? = nil
 ) throws -> String {
     let command = commands.joined(separator: " && ")
 
@@ -75,7 +80,8 @@ import Dispatch
         at: path,
         process: process,
         outputHandle: outputHandle,
-        errorHandle: errorHandle
+        errorHandle: errorHandle,
+        environment: environment
     )
 }
 
@@ -87,6 +93,7 @@ import Dispatch
  *  - parameter process: Which process to use to perform the command (default: A new one)
  *  - parameter outputHandle: Any `FileHandle` that any output (STDOUT) should be redirected to
  *  - parameter errorHandle: Any `FileHandle` that any error output (STDERR) should be redirected to
+ *  - parameter environment: The environment for the command.
  *
  *  - returns: The output of running the command
  *  - throws: `ShellOutError` in case the command couldn't be performed, or it returned an error
@@ -101,14 +108,16 @@ import Dispatch
     at path: String = ".",
     process: Process = .init(),
     outputHandle: FileHandle? = nil,
-    errorHandle: FileHandle? = nil
+    errorHandle: FileHandle? = nil,
+    environment: [String : String]? = nil
 ) throws -> String {
     return try shellOut(
         to: command.string,
         at: path,
         process: process,
         outputHandle: outputHandle,
-        errorHandle: errorHandle
+        errorHandle: errorHandle,
+        environment: environment
     )
 }
 
@@ -397,9 +406,13 @@ extension ShellOutError: LocalizedError {
 // MARK: - Private
 
 private extension Process {
-    @discardableResult func launchBash(with command: String, outputHandle: FileHandle? = nil, errorHandle: FileHandle? = nil) throws -> String {
+    @discardableResult func launchBash(with command: String, outputHandle: FileHandle? = nil, errorHandle: FileHandle? = nil, environment: [String : String]? = nil) throws -> String {
         launchPath = "/bin/bash"
         arguments = ["-c", command]
+
+        if let environment = environment {
+            self.environment = environment
+        }
 
         // Because FileHandle's readabilityHandler might be called from a
         // different queue from the calling queue, avoid a data race by


### PR DESCRIPTION
I didn't see any tests for the predefined git commands but would be happy to add some if it would be helpful.